### PR TITLE
Create organization profile README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,30 @@
+# Welcome to BlueCentre!
+
+This is the official GitHub organization page for BlueCentre. We are dedicated to creating innovative open-source solutions.
+
+## About Us
+
+- **Name:** James H Nguyen
+- **Location:** Irvine, CA
+- **Blog:** [https://gh.ipv1337.dev](https://gh.ipv1337.dev)
+- **Email:** [git@nocentre.net](mailto:git@nocentre.net)
+
+## Our Most Active Projects
+
+Here are some of our projects, sorted by recent activity:
+
+- **[adk-agents](https://github.com/BlueCentre/adk-agents)**: Agents built to run on Google's ADK framework (Last updated: 2025-06-20T23:16:29Z)
+- **[adk-python](https://github.com/BlueCentre/adk-python)**: An open-source, code-first Python toolkit for building, evaluating, and deploying sophisticated AI agents with flexibility and control. (Last updated: 2025-06-18T20:17:36Z)
+- **[monorepo](https://github.com/BlueCentre/monorepo)**: Monorepo Blueprint (Last updated: 2025-06-02T05:13:59Z)
+- **[code-agent](https://github.com/BlueCentre/code-agent)**: Code Agent CLI for interacting with LLMs and local environment (Last updated: 2025-05-07T18:43:48Z)
+- **[cloudrun-go-example](https://github.com/BlueCentre/cloudrun-go-example)**: Example Cloud Run Go Project (Last updated: 2021-02-01T05:09:30Z)
+- **[container-workspace](https://github.com/BlueCentre/container-workspace)**: Typical DevOps Workspace (Last updated: 2019-05-27T03:23:56Z)
+- **[terraform-workspace](https://github.com/BlueCentre/terraform-workspace)**: null (Last updated: 2018-09-07T06:00:32Z)
+- **[ansible-redhat-openstack](https://github.com/BlueCentre/ansible-redhat-openstack)**: Ansible automation content for Red Hat Deployed OpenStack (Last updated: 2013-06-10T23:17:06Z)
+
+## Get Involved
+
+We welcome contributions and collaborations! Feel free to explore our projects, open issues, or submit pull requests.
+
+---
+*This page was automatically generated.*


### PR DESCRIPTION
This commit creates a README.md file for the .github repository to serve as the organization's profile page.

It includes:
- Organization details (name, location, blog, email)
- A list of the most active public repositories, sorted by recent activity, with links and descriptions.
- Introductory and concluding text with a call to action for contributions.